### PR TITLE
Add az login support for azure credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ Azure utilities are under the `azure` sub-command. For authentication, Azure com
   * Environment: `${AZURE_TENANT_ID}`
   * Args: `--tenant <tenant-id>`
 
+Alternatively the [azure cli](https://docs.microsoft.com/en-us/cli/azure/install-azure-cli?view=azure-cli-latest) can be used to authenticate in the current shell with `az login`.
+
 See `dockcmd azure --help` for more details on `azure` flags.
 
 ### `get-secrets`


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

Adds the ability to use `az login` in conjunction with `dockcmd azure`. If you do not provide a `tenant`, `client-id` and `client-secret` then `dockcmd azure` will attempt to use your current `az login` session. Alternatively if you can force `dockcmd azure` to attempt to use your current `az login` with `--az-cli-login`. If you do not have an active `az login` session then an error message will be printed:
```
Invoking Azure CLI failed with the following error: ERROR: Please run 'az login' to setup account.
```