### PR TITLE
Add cache ttl

### DIFF
--- a/cmd/aws.go
+++ b/cmd/aws.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 BoxBoat engineering@boxboat.com
+// Copyright © 2021 BoxBoat engineering@boxboat.com
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -157,5 +157,4 @@ func init() {
 	common.AddInputFileSupport(awsGetSecretsCmd, &common.GetSecretsInputFile)
 	common.AddOutputFileSupport(awsGetSecretsCmd, &common.GetSecretsOutputFile)
 
-	aws.SecretCache = make(map[string]map[string]interface{})
 }

--- a/cmd/aws/aws.go
+++ b/cmd/aws/aws.go
@@ -42,6 +42,10 @@ var (
 	CacheTTL             = 5 * time.Minute
 )
 
+func init(){
+	SecretCache = cache.New(CacheTTL, CacheTTL)
+}
+
 // SessionProvider custom provider to allow for fallback to session configured credentials.
 type SessionProvider struct {
 	Session *session.Session
@@ -58,7 +62,6 @@ func (m *SessionProvider) IsExpired() bool {
 }
 
 func getAwsCredentials(sess *session.Session) *credentials.Credentials {
-
 	var creds = sess.Config.Credentials
 	if UseChainCredentials {
 		creds = credentials.NewChainCredentials(
@@ -102,11 +105,6 @@ func getAwsSecretsManagerClient() *secretsmanager.SecretsManager {
 }
 
 func GetAwsSecret(secretName string, secretKey string) string {
-
-	if SecretCache == nil {
-		SecretCache = cache.New(CacheTTL, CacheTTL)
-	}
-
 	common.Logger.Debugf("Retrieving %s", secretName)
 	if val, ok := SecretCache.Get(secretName); ok {
 		common.Logger.Debugf("Using cached [%s][%s]", secretName, secretKey)
@@ -192,5 +190,4 @@ func GetAwsSecret(secretName string, secretKey string) string {
 	_ = SecretCache.Add(secretName, response, cache.DefaultExpiration)
 
 	return secretStr
-
 }

--- a/cmd/azure.go
+++ b/cmd/azure.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 BoxBoat engineering@boxboat.com
+// Copyright © 2021 BoxBoat engineering@boxboat.com
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@ import (
 	"github.com/boxboat/dockcmd/cmd/common"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"os"
 	"text/template"
 )
 
@@ -39,12 +38,8 @@ func azureCmdPersistentPreRunE(cmd *cobra.Command, args []string) error {
 	if (azure.TenantID == "" && azure.ClientID == "" && azure.ClientSecret == "") || azure.UseAzCliLogin {
 		// set to true in case where no service principal credentials provided
 		azure.UseAzCliLogin = true
-	} else {
-		// ensure required environment variables are set
-		os.Setenv("AZURE_TENANT_ID", azure.TenantID)
-		os.Setenv("AZURE_CLIENT_ID", azure.ClientID)
-		os.Setenv("AZURE_CLIENT_SECRET", azure.ClientSecret)
 	}
+
 	return nil
 }
 
@@ -55,7 +50,7 @@ var azureCmd = &cobra.Command{
 	Long:              `Commands designed to facilitate interactions with Azure`,
 	PersistentPreRunE: azureCmdPersistentPreRunE,
 	Run: func(cmd *cobra.Command, args []string) {
-		cmd.Help()
+		_ = cmd.Help()
 	},
 }
 
@@ -130,7 +125,7 @@ func init() {
 		"",
 		"",
 		"Azure tenant ID can alternatively be set using ${AZURE_TENANT_ID}")
-	viper.BindEnv("tenant", "AZURE_TENANT_ID")
+	_ = viper.BindEnv("tenant", "AZURE_TENANT_ID")
 
 	azureCmd.PersistentFlags().StringVarP(
 		&azure.ClientID,
@@ -146,10 +141,10 @@ func init() {
 		"",
 		"Azure Client Secret Key can alternatively be set using ${AZURE_CLIENT_SECRET}")
 
-	viper.BindEnv("tenant", "AZURE_TENANT_ID")
-	viper.BindEnv("client-id", "AZURE_CLIENT_ID")
-	viper.BindEnv("client-secret", "AZURE_CLIENT_SECRET")
-	viper.BindPFlags(azureCmd.PersistentFlags())
+	_ = viper.BindEnv("tenant", "AZURE_TENANT_ID")
+	_ = viper.BindEnv("client-id", "AZURE_CLIENT_ID")
+	_ = viper.BindEnv("client-secret", "AZURE_CLIENT_SECRET")
+	_ = viper.BindPFlags(azureCmd.PersistentFlags())
 
 	azureGetSecretsCmd.PersistentFlags().StringVarP(
 		&azure.KeyVaultName,
@@ -165,5 +160,4 @@ func init() {
 	common.AddInputFileSupport(azureGetSecretsCmd, &common.GetSecretsInputFile)
 	common.AddOutputFileSupport(azureGetSecretsCmd, &common.GetSecretsOutputFile)
 
-	azure.SecretCache = make(map[string]map[string]interface{})
 }

--- a/cmd/azure/azure.go
+++ b/cmd/azure/azure.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 BoxBoat engineering@boxboat.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package azure
 
 import (
@@ -7,6 +21,8 @@ import (
 	"github.com/Azure/azure-sdk-for-go/profiles/2019-03-01/keyvault/keyvault"
 	kvauth "github.com/Azure/azure-sdk-for-go/services/keyvault/auth"
 	"github.com/boxboat/dockcmd/cmd/common"
+	"os"
+	"time"
 )
 
 var (
@@ -16,8 +32,9 @@ var (
 	ClientSecret   string
 	KeyVaultName   string
 	KeyVaultClient keyvault.BaseClient
-	SecretCache    map[string]map[string]interface{}
+	SecretCache    map[string]common.SecretCacheItem
 	UseAzCliLogin  = false
+	CacheTTL       = 5.0
 )
 
 func getKeyVaultClient() keyvault.BaseClient {
@@ -29,6 +46,11 @@ func getKeyVaultClient() keyvault.BaseClient {
 			KeyVaultClient.Authorizer = authorizer
 			initialized = true
 		} else {
+			// ensure required environment variables are set
+			os.Setenv("AZURE_TENANT_ID", TenantID)
+			os.Setenv("AZURE_CLIENT_ID", ClientID)
+			os.Setenv("AZURE_CLIENT_SECRET", ClientSecret)
+
 			authorizer, err := kvauth.NewAuthorizerFromEnvironment()
 			common.HandleError(err)
 			KeyVaultClient = keyvault.New()
@@ -42,13 +64,17 @@ func getKeyVaultClient() keyvault.BaseClient {
 func GetAzureJSONSecret(secretName string, secretKey string) string {
 	common.Logger.Debugf("Retrieving [%s][%s]", secretName, secretKey)
 
-	if val, ok := SecretCache[secretName]; ok {
+	if SecretCache == nil {
+		SecretCache = make(map[string]common.SecretCacheItem)
+	}
+
+	if val, ok := SecretCache[secretName]; ok && time.Since(val.CachedAt).Minutes() < CacheTTL {
 		common.Logger.Debugf("Using cached [%s][%s]", secretName, secretKey)
-		secretStr, ok := val[secretKey].(string)
+		secretStr, ok := val.Secret[secretKey].(string)
 		if !ok {
 			common.HandleError(
 				fmt.Errorf(
-					"Could not convert [%s][%s] to string",
+					"could not convert [%s][%s] to string",
 					secretName,
 					secretKey))
 		}
@@ -62,7 +88,9 @@ func GetAzureJSONSecret(secretName string, secretKey string) string {
 	common.HandleError(err)
 	secretJSON := *secretResp.Value
 	var response map[string]interface{}
-	json.Unmarshal([]byte(secretJSON), &response)
+	if err := json.Unmarshal([]byte(secretJSON), &response); err != nil {
+		common.HandleError(err)
+	}
 
 	secretStr, ok := response[secretKey].(string)
 	if !ok {
@@ -72,15 +100,33 @@ func GetAzureJSONSecret(secretName string, secretKey string) string {
 				secretName,
 				secretKey))
 	}
-	if SecretCache[secretName] == nil {
-		SecretCache[secretName] = make(map[string]interface{})
+
+	SecretCache[secretName] = common.SecretCacheItem{
+		Secret:   response,
+		CachedAt: time.Now(),
 	}
-	SecretCache[secretName] = response
 	return secretStr
 }
 
 func GetAzureTextSecret(secretName string) string {
 	common.Logger.Debugf("GetAzureTextSecret [%s]", secretName)
+
+	if SecretCache == nil {
+		SecretCache = make(map[string]common.SecretCacheItem)
+	}
+
+	if val, ok := SecretCache[secretName]; ok && time.Since(val.CachedAt).Minutes() < CacheTTL {
+		common.Logger.Debugf("Using cached [%s][%s]", secretName, secretName)
+		secretStr, ok := val.Secret[secretName].(string)
+		if !ok {
+			common.HandleError(
+				fmt.Errorf(
+					"could not convert [%s][%s] to string",
+					secretName,
+					secretName))
+		}
+		return secretStr
+	}
 
 	secretResp, err := getKeyVaultClient().GetSecret(
 		context.Background(),
@@ -88,6 +134,15 @@ func GetAzureTextSecret(secretName string) string {
 		secretName, "")
 	common.HandleError(err)
 	secretStr := *secretResp.Value
+
+	var response = make(map[string]interface{})
+	// only one secret is stored with azureText so just cache at secretName in map
+	response[secretName] = secretStr
+
+	SecretCache[secretName] = common.SecretCacheItem{
+		Secret:   response,
+		CachedAt: time.Now(),
+	}
 
 	return secretStr
 

--- a/cmd/azure/azure.go
+++ b/cmd/azure/azure.go
@@ -38,6 +38,10 @@ var (
 	CacheTTL       = 5 * time.Minute
 )
 
+func init(){
+	SecretCache = cache.New(CacheTTL, CacheTTL)
+}
+
 func getKeyVaultClient() keyvault.BaseClient {
 	if !initialized {
 		if UseAzCliLogin {
@@ -64,10 +68,6 @@ func getKeyVaultClient() keyvault.BaseClient {
 
 func GetAzureJSONSecret(secretName string, secretKey string) string {
 	common.Logger.Debugf("Retrieving [%s][%s]", secretName, secretKey)
-
-	if SecretCache == nil {
-		SecretCache = cache.New(CacheTTL, CacheTTL)
-	}
 
 	if val, ok := SecretCache.Get(secretName); ok {
 		common.Logger.Debugf("Using cached [%s][%s]", secretName, secretKey)
@@ -109,10 +109,6 @@ func GetAzureJSONSecret(secretName string, secretKey string) string {
 
 func GetAzureTextSecret(secretName string) string {
 	common.Logger.Debugf("GetAzureTextSecret [%s]", secretName)
-
-	if SecretCache == nil {
-		SecretCache = cache.New(CacheTTL, CacheTTL)
-	}
 
 	if val, ok := SecretCache.Get(secretName); ok {
 		common.Logger.Debugf("Using cached [%s]", secretName)

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 BoxBoat engineering@boxboat.com
+// Copyright © 2021 BoxBoat engineering@boxboat.com
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import (
 	"os"
 	"strings"
 	"text/template"
+	"time"
 
 	"sigs.k8s.io/yaml"
 
@@ -53,6 +54,11 @@ var (
 	ValuesFiles          []string
 	ValuesMap            = map[string]interface{}{}
 )
+
+type SecretCacheItem struct {
+	Secret   map[string]interface{}
+	CachedAt time.Time
+}
 
 // AddEditInPlaceSupport will add the standard edit in place option and store
 // the user input in the provided bool variable.

--- a/cmd/common/common.go
+++ b/cmd/common/common.go
@@ -20,11 +20,9 @@ import (
 	"io/ioutil"
 	"net/url"
 	"os"
+	"sigs.k8s.io/yaml"
 	"strings"
 	"text/template"
-	"time"
-
-	"sigs.k8s.io/yaml"
 
 	"github.com/Masterminds/sprig/v3"
 	log "github.com/sirupsen/logrus"
@@ -54,11 +52,6 @@ var (
 	ValuesFiles          []string
 	ValuesMap            = map[string]interface{}{}
 )
-
-type SecretCacheItem struct {
-	Secret   map[string]interface{}
-	CachedAt time.Time
-}
 
 // AddEditInPlaceSupport will add the standard edit in place option and store
 // the user input in the provided bool variable.

--- a/cmd/elastic/elastic.go
+++ b/cmd/elastic/elastic.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 BoxBoat engineering@boxboat.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package elastic
 
 import (

--- a/cmd/vault.go
+++ b/cmd/vault.go
@@ -1,4 +1,4 @@
-// Copyright © 2019 BoxBoat engineering@boxboat.com
+// Copyright © 2021 BoxBoat engineering@boxboat.com
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -150,10 +150,10 @@ func init() {
 		"",
 		"Vault Secret Id if not using vault-token can alternatively be set using ${VAULT_SECRET_ID} (also requires vault-role-id)")
 
-	viper.BindEnv("vault-token", "VAULT_TOKEN")
-	viper.BindEnv("vault-role-id", "VAULT_ROLE_ID")
-	viper.BindEnv("vault-secret-id", "VAULT_SECRET_ID")
-	viper.BindPFlags(vaultCmd.PersistentFlags())
+	_ = viper.BindEnv("vault-token", "VAULT_TOKEN")
+	_ = viper.BindEnv("vault-role-id", "VAULT_ROLE_ID")
+	_ = viper.BindEnv("vault-secret-id", "VAULT_SECRET_ID")
+	_ = viper.BindPFlags(vaultCmd.PersistentFlags())
 
 	common.AddSetValuesSupport(vaultGetSecretsCmd, &common.Values)
 	common.AddValuesFileSupport(vaultGetSecretsCmd, &common.ValuesFiles)
@@ -163,5 +163,4 @@ func init() {
 	common.AddInputFileSupport(vaultGetSecretsCmd, &common.GetSecretsInputFile)
 	common.AddOutputFileSupport(vaultGetSecretsCmd, &common.GetSecretsOutputFile)
 
-	vault.SecretCache = make(map[string]map[string]interface{})
 }

--- a/cmd/vault/vault.go
+++ b/cmd/vault/vault.go
@@ -1,3 +1,17 @@
+// Copyright © 2021 BoxBoat engineering@boxboat.com
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package vault
 
 import (
@@ -5,6 +19,7 @@ import (
 	"fmt"
 	"github.com/boxboat/dockcmd/cmd/common"
 	"github.com/hashicorp/vault/api"
+	"time"
 )
 
 const (
@@ -19,7 +34,8 @@ var (
 	Token       string
 	RoleID      string
 	SecretID    string
-	SecretCache map[string]map[string]interface{}
+	SecretCache map[string]common.SecretCacheItem
+	CacheTTL    = 5.0
 )
 
 func getVaultClient() *api.Client {
@@ -55,9 +71,12 @@ func getVaultClient() *api.Client {
 }
 
 func GetVaultSecret(path string, key string) string {
-	if val, ok := SecretCache[path]; ok {
+	if SecretCache == nil {
+		SecretCache = make(map[string]common.SecretCacheItem)
+	}
+	if val, ok := SecretCache[path]; ok && time.Since(val.CachedAt).Minutes() < CacheTTL {
 		common.Logger.Debugf("Using cached [%s][%s]", path, key)
-		secretStr, ok := val[key].(string)
+		secretStr, ok := val.Secret[key].(string)
 		if !ok {
 			common.HandleError(
 				fmt.Errorf(
@@ -70,12 +89,6 @@ func GetVaultSecret(path string, key string) string {
 
 	common.Logger.Debugf("Reading secret[%s] key[%s]", path, key)
 
-	if SecretCache[path] == nil {
-		SecretCache[path] = make(map[string]interface{})
-	}
-
-
-
 	secretStr := ""
 	ok := false
 
@@ -84,7 +97,7 @@ func GetVaultSecret(path string, key string) string {
 	if v2 {
 		queryPath := addPrefixToVKVPath(path, mountPath, "data")
 		// make empty query for ReadWithData (always retrieve latest secret from v2 kv store)
-		query := make(map[string][] string)
+		query := make(map[string][]string)
 		secret, err := getVaultClient().Logical().ReadWithData(queryPath, query)
 		common.HandleError(err)
 		if secret != nil {
@@ -97,7 +110,10 @@ func GetVaultSecret(path string, key string) string {
 					path,
 					key))
 		}
-		SecretCache[path] = secret.Data["data"].(map[string]interface{})
+		SecretCache[path] = common.SecretCacheItem{
+			Secret: secret.Data["data"].(map[string]interface{}),
+			CachedAt: time.Now(),
+		}
 	} else {
 		secret, err := getVaultClient().Logical().Read(path)
 		common.HandleError(err)
@@ -111,7 +127,10 @@ func GetVaultSecret(path string, key string) string {
 					path,
 					key))
 		}
-		SecretCache[path] = secret.Data
+		SecretCache[path] = common.SecretCacheItem{
+			Secret: secret.Data,
+			CachedAt: time.Now(),
+		}
 	}
 
 	return secretStr

--- a/cmd/vault/vault.go
+++ b/cmd/vault/vault.go
@@ -39,6 +39,10 @@ var (
 	CacheTTL    = 5 * time.Minute
 )
 
+func init(){
+	SecretCache = cache.New(CacheTTL, CacheTTL)
+}
+
 func getVaultClient() *api.Client {
 	if Client == nil {
 		config := api.DefaultConfig()
@@ -72,10 +76,6 @@ func getVaultClient() *api.Client {
 }
 
 func GetVaultSecret(path string, key string) string {
-
-	if SecretCache == nil {
-		SecretCache = cache.New(CacheTTL, CacheTTL)
-	}
 
 	if val, ok := SecretCache.Get(path); ok {
 		common.Logger.Debugf("Using cached [%s][%s]", path, key)

--- a/go.mod
+++ b/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/mattn/go-isatty v0.0.12 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/reflectwalk v1.0.1 // indirect
+	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pierrec/lz4 v2.2.6+incompatible // indirect
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -837,6 +837,7 @@ github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIw
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
+github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=


### PR DESCRIPTION
Signed-off-by: Matthew DeVenny <matt@boxboat.com>

Adds cache TTL to the secrets packages to allow extension and reuse of the aws, azure and vault packages.