### PR TITLE
Switch to chainguard images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 ARG VERSION=develop
 ARG GO_VERSION=1.23.4
 
-FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-alpine as build
+FROM --platform=${BUILDPLATFORM} cgr.dev/chainguard/go:latest-dev as build
 
-RUN apk --no-cache add make ca-certificates
 RUN adduser -D dockcmd
 WORKDIR /src
 COPY go.mod go.sum /src/
@@ -16,7 +15,7 @@ RUN GOOS=${TARGETOS} GOARCH=${TARGETARCH} VERSION=${VERSION} make build
 USER dockcmd
 ENTRYPOINT [ "/src/bin/dockcmd" ]
 
-FROM --platform=${TARGETPLATFORM} gcr.io/distroless/static as release
+FROM --platform=${TARGETPLATFORM} cgr.dev/chainguard/static as release
 
 COPY --from=build /etc/passwd /etc/group /etc/
 COPY --from=build /src/bin/dockcmd /bin/dockcmd


### PR DESCRIPTION
For a couple reasons:

1. security; and
2. so we're always using a current golang version to build dockcmd with.